### PR TITLE
Add logging code

### DIFF
--- a/src/sample_int_crank.cpp
+++ b/src/sample_int_crank.cpp
@@ -141,6 +141,9 @@ IntegerVector sample_int_expj(int n, int size, NumericVector prob) {
     // Incrementing iprob is part of Step 7
     for (NumericVector::iterator iprob = prob.begin() + size; iprob != prob.end(); ++iprob) {
 
+      fprintf(stderr, "T_w: %f %d\n", T_w.first, T_w.second);
+      fprintf(stderr, "R.top(): %f %d\n", R.top().first, R.top().second);
+
       // Step 5: Let r = random(0, 1) and X_w = log(r) / log(T_w)
       // (Modification: Use e = -exp(1) instead of log(r))
       double X_w = Rf_rexp(1.0) / T_w.first;


### PR DESCRIPTION
to understand buggy expj routine.

``` r
set.seed(20200407)

wrswoR::sample_int_expj(10, 5, 1:10)
#> 0.436870 1
#> 0.436870 1
#> 0.251545 5
#> 0.251545 5
#> 0.230631 7
#> 0.230631 7
#> 0.179321 3
#> 0.179321 3
#> [1] 10  8  2  6  4
```

<sup>Created on 2020-04-07 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>