### PR TITLE
fledge: CRAN release v1.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: wrswoR
 Title: Weighted Random Sampling without Replacement
-Version: 1.2.0.9008
+Version: 1.2.1
 Date: 2026-05-13
 Authors@R: 
     person(given = "Kirill",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,55 +4,9 @@
 
 ## Chore
 
-- Auto-update from GitHub Actions (#71).
-
-- Add ccache to `.gitignore` and `.Rbuildignore`.
-
-- Auto-update from GitHub Actions (#60).
-
-- Auto-update from GitHub Actions (#58).
+- Replace logging dependency with otel (#67).
 
 - Remove deprecated Rcpp LdFlags from Makevars (#55, #56).
-
-- Auto-update from GitHub Actions (#53).
-
-- Auto-update from GitHub Actions (#43).
-
-## Continuous integration
-
-- Create snapshot update PR against correct branch.
-
-- Add reference to `/apply-patch` workflow in commit message.
-
-- Clarify rationale for not deploying on schedule.
-
-- Only run fledge on pushes to main.
-
-- Tweak fledge workflow and ccache action.
-
-- Cosmetics.
-
-- Bump action versions.
-
-- Install clang-format-21.
-
-- Align fledge workflow.
-
-- Harmonize.
-
-- Fix comment (#51).
-
-- Tweaks (#50).
-
-- Test all R versions on branches that start with cran- (#49).
-
-- Install binaries from r-universe for dev workflow (#47).
-
-- Fix reviewdog and add commenting workflow (#45).
-
-## Refactoring
-
-- Replace logging dependency with otel (#67).
 
 
 # wrswoR 1.2.0 (2025-11-09)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,22 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# wrswoR 1.2.0.9008 (2026-05-13)
+# wrswoR 1.2.1 (2026-05-13)
 
 ## Chore
 
 - Auto-update from GitHub Actions (#71).
 
 - Add ccache to `.gitignore` and `.Rbuildignore`.
+
+- Auto-update from GitHub Actions (#60).
+
+- Auto-update from GitHub Actions (#58).
+
+- Remove deprecated Rcpp LdFlags from Makevars (#55, #56).
+
+- Auto-update from GitHub Actions (#53).
+
+- Auto-update from GitHub Actions (#43).
 
 ## Continuous integration
 
@@ -20,19 +30,6 @@
 
 - Tweak fledge workflow and ccache action.
 
-## Refactoring
-
-- Replace logging dependency with otel (#67).
-
-
-# wrswoR 1.2.0.9007 (2026-05-06)
-
-## Chore
-
-- Auto-update from GitHub Actions (#60).
-
-## Continuous integration
-
 - Cosmetics.
 
 - Bump action versions.
@@ -43,58 +40,19 @@
 
 - Harmonize.
 
-
-# wrswoR 1.2.0.9006 (2026-05-04)
-
-## Chore
-
-- Auto-update from GitHub Actions (#58).
-
-
-# wrswoR 1.2.0.9005 (2026-03-16)
-
-## Chore
-
-- Remove deprecated Rcpp LdFlags from Makevars (#55, #56).
-
-
-# wrswoR 1.2.0.9004 (2026-03-12)
-
-## Chore
-
-- Auto-update from GitHub Actions (#53).
-
-
-# wrswoR 1.2.0.9003 (2026-01-14)
-
-## Continuous integration
-
 - Fix comment (#51).
 
 - Tweaks (#50).
 
 - Test all R versions on branches that start with cran- (#49).
 
-
-# wrswoR 1.2.0.9002 (2025-11-17)
-
-## Continuous integration
-
 - Install binaries from r-universe for dev workflow (#47).
-
-
-# wrswoR 1.2.0.9001 (2025-11-12)
-
-## Continuous integration
 
 - Fix reviewdog and add commenting workflow (#45).
 
+## Refactoring
 
-# wrswoR 1.2.0.9000 (2025-11-10)
-
-## Chore
-
-- Auto-update from GitHub Actions (#43).
+- Replace logging dependency with otel (#67).
 
 
 # wrswoR 1.2.0 (2025-11-09)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,6 +2,6 @@ wrswoR 1.2.1
 
 ## Cran Repository Policy
 
-- [ ] Reviewed CRP last edited 2026-04-21.
+- [x] Reviewed CRP last edited 2026-04-21.
 
 See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2024-08-27%7D...master@%7B2026-04-21%7D

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,7 @@
-wrswoR 1.2.0
+wrswoR 1.2.1
 
 ## Cran Repository Policy
 
-- [x] Reviewed CRP last edited 2024-08-27.
+- [ ] Reviewed CRP last edited 2026-04-21.
 
-See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2020-07-11%7D...master@%7B2024-08-27%7D
+See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2024-08-27%7D...master@%7B2026-04-21%7D


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2026-05-13, no problems found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`