### PR TITLE
ci: ignore `metap` in CI dependency resolution to avoid retired Bioconductor dep

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,6 @@ LinkingTo:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 URLNote: https://github.com/krlmlr/wrswoR
-Config/gha/extra-packages: metap=?ignore-before-r=4.3.0
+Config/gha/extra-packages: metap=?ignore
 Config/testthat/edition: 3
 Config/roxygen2/version: 8.0.0.9000


### PR DESCRIPTION
## Problem

The `rcc` workflow started failing on the daily schedule (first red run 2026-07-17) even though the commit under test (`a74333b`) had not changed and was green on 2026-07-16. The failure is in the **dependency-resolution** step (`pak` lockfile creation), not in R CMD check itself:

```
! Could not solve package dependencies:
* deps::.: Can't install dependency metap
* metap: Can't install dependency mutoss
* mutoss: Can't install dependency multtest (>= 2.2.0)
* multtest: Can't find package called multtest.
```

## Root cause

The suggested package `metap` pulls in `mutoss`, which hard-depends on the Bioconductor package `multtest`. On the GitHub runner, `pak` resolves under its bootstrap R 4.3.3, so it queries **Bioconductor 3.18** — a release that has now been retired from the Posit Bioconductor mirror. The run log's repo-status table shows `BioCsoft … 3.18 … ok=FALSE`, and `multtest` returns HTTP 404 there. This is a genuine upstream change (Bioc 3.18 retirement), which is why a previously-green commit turned red with no source change.

## Fix

Change `Config/gha/extra-packages` from `metap=?ignore-before-r=4.3.0` to `metap=?ignore`.

`?ignore-unavailable` does **not** help here — I verified this with a synthetic 3-level reproduction: `metap` itself resolves fine, and the `metap → mutoss → multtest` links are all hard `Imports`, so `pak` never marks `metap` as unavailable (the `ignore-unavailable` code path only fires when the ref's own status is `FAILED`). The only soft edge is the package's own `Suggests: metap`, so `?ignore` is required to drop the whole chain. `?ignore` also subsumes the previous `?ignore-before-r=4.3.0` intent (old-R handling).

Dropping `metap` from CI installs is safe: it is used only in `vignettes/internal/_wrswoR.Rmd`, which is excluded from the build via `.Rbuildignore` (`^vignettes/internal$`) and is never built by R CMD check or pkgdown. The package declares no `VignetteBuilder` and has no vignette sources directly under `vignettes/`.

## Verification

- Reproduced the exact failure chain synthetically, and confirmed on the real package that default `deps::.` pulls in `metap`, `mutoss`, and `multtest`, whereas `deps::. + metap=?ignore` drops all three.
- Local `rcmdcheck::rcmdcheck(args = "--no-manual")` (with `_R_CHECK_FORCE_SUGGESTS_=false`) → **Status: OK**, 0 errors / 0 warnings / 0 notes, tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7

---
_Generated by [Claude Code](https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7)_